### PR TITLE
add APP_KEY generation and parameter

### DIFF
--- a/charts/pixelfed/Chart.yaml
+++ b/charts/pixelfed/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.1
+version: 0.12.0
 
 # This is the version number of the application being deployed.
 # renovate:image=ghcr.io/mattlqx/docker-pixelfed

--- a/charts/pixelfed/README.md
+++ b/charts/pixelfed/README.md
@@ -1,6 +1,6 @@
 # pixelfed
 
-![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.4-nginx](https://img.shields.io/badge/AppVersion-v0.12.4--nginx-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.4-nginx](https://img.shields.io/badge/AppVersion-v0.12.4--nginx-informational?style=flat-square)
 
 A Helm chart for deploying Pixelfed on Kubernetes
 
@@ -80,6 +80,9 @@ A Helm chart for deploying Pixelfed on Kubernetes
 | pixelfed.admin_domain | string | `""` | domain of admin interface |
 | pixelfed.app.domain | string | `""` | The domain of your server, without https:// |
 | pixelfed.app.env | string | `"production"` | The app environment, keep it set to "production" |
+| pixelfed.app.existingSecret | string | `""` | use an existing Kuberentes Secret to store the app key If set, ignores pixelfed.app.key |
+| pixelfed.app.existingSecretKey | string | `""` | key in pixelfed.app.existingSecret to use for the app key |
+| pixelfed.app.key | string | `""` | This key is used by the Illuminate encrypter service and should be set to a random, 32 character string, otherwise these encrypted strings will not be safe. If you don't generate one, we'll generate one for you however it will change everytime you upgrade the helm chart, so it should only be used for testing. In production, please set this, or pixelfed.app.existingSecret |
 | pixelfed.app.locale | string | `"en"` | change this to the language code of your pixelfed instance |
 | pixelfed.app.name | string | `"Pixelfed"` | The name of your server/instance |
 | pixelfed.app.url | string | `"https://localhost"` | change this to the domain of your pixelfed instance |

--- a/charts/pixelfed/templates/deployment.yaml
+++ b/charts/pixelfed/templates/deployment.yaml
@@ -67,6 +67,18 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
 
+            # pixelfed app key
+            - name: APP_KEY
+              valueFrom:
+                secretKeyRef:
+                  {{- if and .Values.pixelfed.app.existingSecret .Values.pixelfed.app.existingSecretKey }}
+                  name: {{ .Values.pixelfed.app.existingSecret }}
+                  key: {{ .Values.pixelfed.app.existingSecretKey }}
+                  {{- else }}
+                  name: {{ include "pixelfed.fullname" . }}-app-key
+                  key: key
+                  {{- end }}
+
             # valkey AKA redis
             {{- if and .Values.externalValkey.enabled .Values.externalValkey.existingSecretKeys.host }}
             - name: REDIS_HOST

--- a/charts/pixelfed/templates/secret_app_key.yaml
+++ b/charts/pixelfed/templates/secret_app_key.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.pixelfed.app.existingSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pixelfed.fullname" . }}-app-key
+data:
+  {{ if .Values.pixelfed.app.key }}
+  key: {{ .Values.pixelfed.app.key | b64enc }}
+  {{- else }}
+  key: {{ randAlphaNum 32 | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -305,6 +305,17 @@ pixelfed:
 
   # app specific settings
   app:
+    # -- This key is used by the Illuminate encrypter service and should
+    # be set to a random, 32 character string, otherwise these encrypted strings
+    # will not be safe. If you don't generate one, we'll generate one for you
+    # however it will change everytime you upgrade the helm chart, so it should
+    # only be used for testing. In production, please set this, or pixelfed.app.existingSecret
+    key: ""
+    # -- use an existing Kuberentes Secret to store the app key
+    # If set, ignores pixelfed.app.key
+    existingSecret: ""
+    # -- key in pixelfed.app.existingSecret to use for the app key
+    existingSecretKey: ""
     # -- The name of your server/instance
     name: "Pixelfed"
     # -- The app environment, keep it set to "production"

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -54,16 +54,18 @@ podLabels: {}
 
 # -- securityContext for the whole pod
 podSecurityContext: {}
-  # fsGroup: 2000
+  # runAsUser: 33
+  # runAsGroup: 33
+  # fsGroup: 33
 
 # -- securityContext for the pixelfed container
 securityContext: {}
+  # runAsUser: 33
+  # runAsNonRoot: true
+  # readOnlyRootFilesystem: true
   # capabilities:
   #   drop:
   #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:


### PR DESCRIPTION
Apparently this is necessary and I completely missed it because it's not in the main [docs](https://docs.pixelfed.org/running-pixelfed/configuration.html) I was a reading:
https://github.com/pixelfed/pixelfed/blob/13af8c5133aef4708f599488f678c09325ac417c/.env.docker#L893-L904

This PR adds these parameters:

```yaml
pixelfed:
  # app specific settings
  app:
    # -- This key is used by the Illuminate encrypter service and should
    # be set to a random, 32 character string, otherwise these encrypted strings
    # will not be safe. If you don't generate one, we'll generate one for you
    # however it will change everytime you upgrade the helm chart, so it should
    # only be used for testing. In production, please set this, or pixelfed.app.existingSecret
    key: ""
    # -- use an existing Kuberentes Secret to store the app key
    # If set, ignores pixelfed.app.key
    existingSecret: ""
    # -- key in pixelfed.app.existingSecret to use for the app key
    existingSecretKey: ""
```