### PR TITLE
Features/add more undocumented env vars

### DIFF
--- a/charts/pixelfed/Chart.yaml
+++ b/charts/pixelfed/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed.
 # renovate:image=ghcr.io/mattlqx/docker-pixelfed

--- a/charts/pixelfed/templates/configmap_env.yaml
+++ b/charts/pixelfed/templates/configmap_env.yaml
@@ -23,6 +23,8 @@ data:
 
   # not sure where to put this
   CUSTOM_EMOJI: {{ .Values.pixelfed.custom_emoji | quote }}
+  CUSTOM_EMOJI_MAX_SIZE: {{ .Values.pixelfed.custom_emoji | quote }}
+  MEDIA_TYPES: {{ .Values.pixelfed.media_types }}
 
   # limits
   MIN_PASSWORD_LENGTH: {{ .Values.pixelfed.min_password_length | quote }}
@@ -40,6 +42,7 @@ data:
   # instance config
   INSTANCE_DESCRIPTION: {{ .Values.pixelfed.instance.description | quote }}
   INSTANCE_CONTACT_FORM: {{ .Values.pixelfed.instance.contact_form | quote }}
+  INSTANCE_CONTACT_MAX_PER_DAY: {{ .Values.pixelfed.instance.contact_max_per_day | quote }}
   INSTANCE_DISCOVER_PUBLIC: {{ .Values.pixelfed.instance.discover_public | quote }}
   INSTANCE_PUBLIC_HASHTAGS: {{ .Values.pixelfed.instance.public_hashtags | quote }}
   {{- with .Values.pixelfed.instance.contact_email }}
@@ -77,7 +80,16 @@ data:
   QUEUE_DRIVER: "redis"
   BROADCAST_DRIVER: "log"
   LOG_CHANNEL: {{ .Values.pixelfed.laravel.log_channel }}
-  HORIZON_PREFIX: "horizon-"
+  LOG_LEVEL: {{ .Values.pixelfed.laravel.log_level }}
+
+  # horizon
+  HORIZON_PREFIX: {{ .Values.pixelfed.horizon.prefix | quote }}
+  HORIZON_DARKMODE: {{ .Values.pixelfed.horizon.darkmode | quote }}
+
+  # filesystem
+  FILESYSTEM_DRIVER: {{ .Values.pixelfed.filesystem.driver }}
+  FILESYSTEM_CLOUD: {{ .Values.pixelfed.filesystem.cloud }}
+  MEDIA_DELETE_LOCAL_AFTER_CLOUD: {{ .Values.pixelfed.media_delete_local_after_cloud }}
 
   # activity pub
   ACTIVITY_PUB: {{ .Values.pixelfed.activity_pub.enabled | quote }}
@@ -85,6 +97,7 @@ data:
   AP_SHAREDINBOX: {{ .Values.pixelfed.activity_pub.sharedinbox | quote }}
   AP_INBOX: {{ .Values.pixelfed.activity_pub.inbox | quote }}
   AP_OUTBOX: {{ .Values.pixelfed.activity_pub.outbox | quote }}
+  AP_LOGGER_ENABLED: {{ .Values.pixelfed.activity_pub.logger_enabled | quote }}
 
   # mail
   MAIL_DRIVER: "{{ .Values.pixelfed.mail.driver }}"

--- a/charts/pixelfed/templates/configmap_env.yaml
+++ b/charts/pixelfed/templates/configmap_env.yaml
@@ -91,6 +91,13 @@ data:
   FILESYSTEM_CLOUD: {{ .Values.pixelfed.filesystem.cloud }}
   MEDIA_DELETE_LOCAL_AFTER_CLOUD: {{ .Values.pixelfed.media_delete_local_after_cloud }}
 
+  # covid
+  ENABLE_COVID_LABEL: {{ .Values.pixelfed.covid.enable_label }}
+  COVID_LABEL_URL: {{ .Values.pixelfed.covid.label_url }}
+  COVID_LABEL_ORG: {{ .Values.pixelfed.covid.label_org }}
+
+  BANNED_USERNAMES: {{ .Values.pixelfed.banned_usernames }}
+
   # activity pub
   ACTIVITY_PUB: {{ .Values.pixelfed.activity_pub.enabled | quote }}
   AP_REMOTE_FOLLOW: {{ .Values.pixelfed.activity_pub.remote_follow | quote }}

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -299,6 +299,15 @@ pixelfed:
     cloud: "s3"
     driver: "local"
 
+  covid:
+    enable_label: true
+    label_url: "https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public"
+    label_org: "visit the WHO website"
+
+  # -- not entirely sure if this is a list of banned usernames or text to
+  # display instead of banned usernames
+  banned_usernames: ""
+
   # -- delete local files after saving to the cloud
   media_delete_local_after_cloud: true
 

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -352,6 +352,8 @@ pixelfed:
   laravel:
     # -- Laravel log channel. Pixelfed's default, 'stack', sends logs to the default Laravel logfile. 'stderr' allows Kubernetes to capture these logs
     log_channel: stack
+    # -- logging level
+    log_level: "debug"
 
   # -- Enable open registration for new accounts
   open_registration: true

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -292,6 +292,16 @@ pixelfed:
     # -- Automatically run [artisan migrate --force] if new migrations are detected.
     apply_new_migrations_automatically: false
 
+  filesystem:
+    # -- Many applications store files both locally and in the cloud.
+    # For this reason, you may specify a default “cloud” driver here.
+    # This driver will be bound as the Cloud disk implementation in the container.
+    cloud: "s3"
+    driver: "local"
+
+  # -- delete local files after saving to the cloud
+  media_delete_local_after_cloud: true
+
   # -- timezone for docker container
   timezone: "europe/amsterdam"
 
@@ -306,6 +316,13 @@ pixelfed:
 
   # -- trusted proxies
   trusted_proxies: "*"
+
+  # horizon - for interfacing with redis
+  horizon:
+    # -- prefix will be used when storing all Horizon data in Redis
+    prefix: "horizon-"
+    # -- darkmode for the web interface in the admin panel
+    dark_mode: false
 
   # app specific settings
   app:
@@ -357,6 +374,12 @@ pixelfed:
   # -- Enable custom emojis
   custom_emoji: false
 
+  # -- max size for custom emojis, in... bytes?
+  custom_emoji_max_size: 2000000
+
+  # -- types of media to allow
+  media_types: "image/jpeg,image/png,image/gif"
+
   # -- Enable the config cache to allow you to manage settings via the admin dashboard
   enable_config_cache: true
 
@@ -387,18 +410,26 @@ pixelfed:
   # -- Force https url generation
   force_https_urls: true
 
+  # -- exp loops (as in loops video? 🤷
+  exp_loops: false
+
+  # -- library to process images. options: "gd" (default), "imagick"
+  image_driver: "gd"
+
   # your whole instance, or server, settings
   instance:
     # -- your server description
     description: "Pixelfed - Photo sharing for everyone"
-    # -- enable the instance contact form
-    contact_form: false
     # -- Enable public access to the Discover feature
     discover_public: false
     # -- Allow anonymous access to hashtag feeds
     public_hashtags: false
+    # -- enable the instance contact form
+    contact_form: false
     # -- The public contact email for your server
     contact_email: ""
+    # -- instance contact max per day
+    contact_max_per_day: ""
     # -- Enable the profile embed feature
     profile_embeds: true
     # -- Enable the post embed feature
@@ -457,6 +488,8 @@ pixelfed:
     inbox: false
     outbox: false
     sharedinbox: false
+    # activity pub logger?
+    logger_enabled: false
 
   ###########################################################
   # Federation
@@ -475,6 +508,7 @@ pixelfed:
     # -- options: "smtp" (default), "sendmail", "mailgun", "mandrill", "ses"
     # "sparkpost", "log", "array"
     driver: smtp
+    # -- mail server hostname
     host: smtp.mailtrap.io
     # -- mail server port
     port: 2525
@@ -491,6 +525,7 @@ pixelfed:
 
     # -- name of an existing Kubernetes Secret for mail credentials
     existingSecret: ""
+    # keys in existing secret
     existingSecretKeys:
       # --  key in existing Kubernetes Secret for host. If set, ignores mail.host
       host: ""


### PR DESCRIPTION
Adds the following new parameters (found either directly in the .env.docker file or in the admin interface):

```yaml
pixelfed:
  filesystem:
    # -- Many applications store files both locally and in the cloud.
    # For this reason, you may specify a default “cloud” driver here.
    # This driver will be bound as the Cloud disk implementation in the container.
    cloud: "s3"
    driver: "local"

  covid:
    enable_label: true
    label_url: "https://www.who.int/emergencies/diseases/novel-coronavirus-2019/advice-for-public"
    label_org: "visit the WHO website"

  # -- not entirely sure if this is a list of banned usernames or text to
  # display instead of banned usernames
  banned_usernames: ""

  # -- delete local files after saving to the cloud
  media_delete_local_after_cloud: true

  # horizon - for interfacing with redis
  horizon:
    # -- prefix will be used when storing all Horizon data in Redis
    prefix: "horizon-"
    # -- darkmode for the web interface in the admin panel
    dark_mode: false

  # -- max size for custom emojis, in... bytes?
  custom_emoji_max_size: 2000000

  # -- types of media to allow
  media_types: "image/jpeg,image/png,image/gif"

  # -- exp loops (as in loops video? 🤷
  exp_loops: false

  # -- library to process images. options: "gd" (default), "imagick"
  image_driver: "gd"

  instance:
    # -- instance contact max per day
    contact_max_per_day: ""

  activitypub:
    # activity pub logger?
    logger_enabled: false
```