### PR TITLE
Minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
 
-TICKET.md
-TASK.md
-COMMITMSG.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+TICKET.md
+TASK.md
+COMMITMSG.md

--- a/charts/pixelfed/Chart.yaml
+++ b/charts/pixelfed/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.3
+version: 0.14.4
 
 # This is the version number of the application being deployed.
 # renovate:image=ghcr.io/mattlqx/docker-pixelfed

--- a/charts/pixelfed/README.md
+++ b/charts/pixelfed/README.md
@@ -1,6 +1,6 @@
 # pixelfed
 
-![Version: 0.14.3](https://img.shields.io/badge/Version-0.14.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.4-nginx](https://img.shields.io/badge/AppVersion-v0.12.4--nginx-informational?style=flat-square)
+![Version: 0.14.4](https://img.shields.io/badge/Version-0.14.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.4-nginx](https://img.shields.io/badge/AppVersion-v0.12.4--nginx-informational?style=flat-square)
 
 A Helm chart for deploying Pixelfed on Kubernetes
 

--- a/charts/pixelfed/templates/secret_mail.yaml
+++ b/charts/pixelfed/templates/secret_mail.yaml
@@ -1,4 +1,6 @@
 {{- if not .Values.pixelfed.mail.existingSecret }}
+{{- $username := .Values.pixelfed.mail.username | required ".Values.pixelfed.mail.username is required" }}
+{{- $password := .Values.pixelfed.mail.password | required ".Values.pixelfed.mail.password is required" }}
 ---
 apiVersion: v1
 kind: Secret
@@ -8,9 +10,9 @@ data:
   host: {{ .Values.pixelfed.mail.host | b64enc }}
   port: {{ .Values.pixelfed.mail.port | quote | b64enc}}
   {{- if .Values.pixelfed.mail.username }}
-  username: {{ .Values.pixelfed.mail.username | b64enc }}
+  username: {{ $username | b64enc }}
   {{- end }}
   {{- if .Values.pixelfed.mail.password }}
-  password: {{ .Values.pixelfed.mail.password | b64enc }}
+  password: {{ $password | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -269,11 +269,10 @@ postgresql:
   global:
     storageClass: ""
 
-  ## If you get "mkdir: cannot create directory ‘/bitnami/postgresql/data’: Permission denied"
-  ## error, set these
-  ## (This often happens on setups like minikube)
-  # volumePermissions:
-  #   enabled: true
+  volumePermissions:
+    # -- If you get "mkdir: cannot create directory ‘/bitnami/postgresql/data’: Permission denied"
+    # error, set these (This often happens on setups like minikube)
+    enabled: false
 
 # -- PHP Configuration files
 # Will be injected in /usr/local/etc/php-fpm.d

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -61,8 +61,7 @@ podSecurityContext: {}
   # fsGroup: 33
 
 # -- securityContext for the pixelfed container
-securityContext:
-  {}
+securityContext:  {}
   # runAsUser: 33
   # runAsNonRoot: true
   # readOnlyRootFilesystem: true

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -61,7 +61,7 @@ podSecurityContext: {}
   # fsGroup: 33
 
 # -- securityContext for the pixelfed container
-securityContext:  {}
+securityContext: {}
   # runAsUser: 33
   # runAsNonRoot: true
   # readOnlyRootFilesystem: true
@@ -98,7 +98,7 @@ ingress:
   #      - chart-example.local
 
 # -- set resource limits and requests for cpu, memory, and ephemeral storage
-resources:  {}
+resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -108,14 +108,14 @@ resources:  {}
 
 # -- This is to setup the liveness probe
 # more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:  {}
+livenessProbe: {}
   #  httpGet:
   #    path: /api/service/health-check
   #    port: http
 
 # -- This is to setup the readiness probe
 # more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-readinessProbe:  {}
+readinessProbe: {}
   #  httpGet:
   #    path: /api/service/health-check
   #    port: http
@@ -277,7 +277,7 @@ postgresql:
 
 # -- PHP Configuration files
 # Will be injected in /usr/local/etc/php-fpm.d
-phpConfigs:  {}
+phpConfigs: {}
   # www.conf: |-
   #   [www]
   #   user = www-data

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -276,8 +276,9 @@ postgresql:
 
   ## If you get "mkdir: cannot create directory ‘/bitnami/postgresql/data’: Permission denied"
   ## error, set these
-  volumePermissions:
-    enabled: true
+  ## (This often happens on setups like minikube)
+  # volumePermissions:
+  #   enabled: true
 
 # -- PHP Configuration files
 # Will be injected in /usr/local/etc/php-fpm.d

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -115,8 +115,7 @@ livenessProbe:  {}
 
 # -- This is to setup the readiness probe
 # more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-readinessProbe:
-  {}
+readinessProbe:  {}
   #  httpGet:
   #    path: /api/service/health-check
   #    port: http

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -282,8 +282,7 @@ postgresql:
 
 # -- PHP Configuration files
 # Will be injected in /usr/local/etc/php-fpm.d
-phpConfigs:
-  {}
+phpConfigs:  {}
   # www.conf: |-
   #   [www]
   #   user = www-data

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -108,8 +108,7 @@ resources:  {}
 
 # -- This is to setup the liveness probe
 # more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:
-  {}
+livenessProbe:  {}
   #  httpGet:
   #    path: /api/service/health-check
   #    port: http

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -55,13 +55,15 @@ podAnnotations: {}
 podLabels: {}
 
 # -- securityContext for the whole pod
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # runAsUser: 33
   # runAsGroup: 33
   # fsGroup: 33
 
 # -- securityContext for the pixelfed container
-securityContext: {}
+securityContext:
+  {}
   # runAsUser: 33
   # runAsNonRoot: true
   # readOnlyRootFilesystem: true
@@ -98,7 +100,8 @@ ingress:
   #      - chart-example.local
 
 # -- set resource limits and requests for cpu, memory, and ephemeral storage
-resources: {}
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -108,14 +111,16 @@ resources: {}
 
 # -- This is to setup the liveness probe
 # more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe: {}
+livenessProbe:
+  {}
   #  httpGet:
   #    path: /api/service/health-check
   #    port: http
 
 # -- This is to setup the readiness probe
 # more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-readinessProbe: {}
+readinessProbe:
+  {}
   #  httpGet:
   #    path: /api/service/health-check
   #    port: http
@@ -261,7 +266,6 @@ valkey:
   # default: nano
   resourcesPreset: "small"
 
-
 postgresql:
   # -- enable the bundled [postgresql sub chart from Bitnami](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/README.md#parameters).
   # Must set to true if externalDatabase.enabled=false
@@ -270,10 +274,15 @@ postgresql:
   global:
     storageClass: ""
 
+  ## If you get "mkdir: cannot create directory ‘/bitnami/postgresql/data’: Permission denied"
+  ## error, set these
+  volumePermissions:
+    enabled: true
 
 # -- PHP Configuration files
 # Will be injected in /usr/local/etc/php-fpm.d
-phpConfigs: {}
+phpConfigs:
+  {}
   # www.conf: |-
   #   [www]
   #   user = www-data

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -98,8 +98,7 @@ ingress:
   #      - chart-example.local
 
 # -- set resource limits and requests for cpu, memory, and ephemeral storage
-resources:
-  {}
+resources:  {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -55,8 +55,7 @@ podAnnotations: {}
 podLabels: {}
 
 # -- securityContext for the whole pod
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # runAsUser: 33
   # runAsGroup: 33
   # fsGroup: 33


### PR DESCRIPTION
This PR addresses two issues found during testing.

1. When installing the chart on minikube, the PostgreSQL chart complained about permissions. This has been addressed in https://github.com/bitnami/containers/issues/2680#issuecomment-1225131399 and the PR includes this in the values (but commented out so as not to break anything). OP on this linked issue used Microk8s, and I was using Minikube. Locally testing this addition worked.

2. Running the chart with the OOTB values breaks when starting up the main pod due to a missing config key (username). Instead of it breaking during pod startup, I changed the template to fail the install outright if the values are not defined. An alternate solution would be to change the deployment.yaml to include MAIL_USERNAME and MAIL_PASSWORD optionally rather than always.

https://github.com/small-hack/pixelfed-chart/blob/cf128bf9d4ecf907aa6b5bccd2f24e314cd4a910/charts/pixelfed/templates/deployment.yaml#L149-L169