### PR TITLE
Support helm-docs on forks by specifying repo during checkout

### DIFF
--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: "0"
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -50,6 +52,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: "0"
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -25,5 +25,5 @@ jobs:
       - name: Render helm docs inside the README.md and push changes back to PR branch
         uses: jessebot/helm-docs-action@0.0.1
         with:
-          working-dir: charts/pixelfed
+          # working-dir: charts/pixelfed
           git-push: "true"

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Render helm docs inside the README.md and push changes back to PR branch
         uses: jessebot/helm-docs-action@0.0.1

--- a/charts/pixelfed/values.yaml
+++ b/charts/pixelfed/values.yaml
@@ -554,7 +554,7 @@ pixelfed:
       # --  key in existing Kubernetes Secret for password. If set, ignores mail.password
       password: ""
 
-  # Mail Configuration (Post-Installer)
+  # S3 Configuration (Required if .Values.pixelfed.pf.enable_cloud is true)
   s3:
     # -- s3 url including protocol such as https://s3.domain.com
     url: ""


### PR DESCRIPTION
Pretty sure this should fix the issue, if you look at[ the failed logs](
https://github.com/small-hack/pixelfed-chart/actions/runs/12920819241/job/36033779507) it seems to be trying to checkout a branch from this repo rather than the forked repo
