### PR TITLE
Fix indentation for PVC accessModes

### DIFF
--- a/charts/pixelfed/Chart.yaml
+++ b/charts/pixelfed/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.0
+version: 0.19.1
 
 # This is the version number of the application being deployed.
 # renovate:image=ghcr.io/mattlqx/docker-pixelfed

--- a/charts/pixelfed/README.md
+++ b/charts/pixelfed/README.md
@@ -1,6 +1,6 @@
 # Pixelfed Helm Chart
 
-![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square)  ![AppVersion: v0.12.4-nginx](https://img.shields.io/badge/AppVersion-v0.12.4--nginx-informational?style=flat-square)
+![Version: 0.19.1](https://img.shields.io/badge/Version-0.19.1-informational?style=flat-square)  ![AppVersion: v0.12.4-nginx](https://img.shields.io/badge/AppVersion-v0.12.4--nginx-informational?style=flat-square)
 
 A Helm chart for deploying Pixelfed on Kubernetes
 

--- a/charts/pixelfed/templates/pvc.yaml
+++ b/charts/pixelfed/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   storageClassName: {{ .Values.persistence.storageClassName }}
   accessModes:
-    {{- toYaml .Values.persistence.accessModes | indent 4 }}
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.persistence.storage }}


### PR DESCRIPTION
Got an error trying to upgrade to 0.19.0 and adding a PVC:
`Helm upgrade failed for release pixelfed/pixelfed with chart pixelfed@0.19.0: YAML parse error on pixelfed/templates/pvc.yaml: error converting YAML to JSON: yaml: line 7: block sequence entries are not allowed in this context`

Looking around, found a similar [issue](https://github.com/bitnami/charts/issues/2532) and [PR](https://github.com/bitnami/charts/pull/2533/) that fixed by using `nindent` instead of `indent`.

Thanks for creating this chart, it's really great!!