### PR TITLE
fix: Add S3 environment variables and fix REDIS_HOST bug

### DIFF
--- a/charts/pixelfed/templates/configmap_env.yaml
+++ b/charts/pixelfed/templates/configmap_env.yaml
@@ -47,7 +47,7 @@ data:
   INSTANCE_CONTACT_MAX_PER_DAY: {{ .Values.pixelfed.instance.contact_max_per_day | quote }}
   INSTANCE_DISCOVER_PUBLIC: {{ .Values.pixelfed.instance.discover_public | quote }}
   INSTANCE_PUBLIC_HASHTAGS: {{ .Values.pixelfed.instance.public_hashtags | quote }}
-  {{- with .Values.pixelfed.instance.contact_email }}
+  {{- if .Values.pixelfed.instance.contact_email }}
   INSTANCE_CONTACT_EMAIL: {{ .Values.pixelfed.instance.contact_email }}
   {{- end }}
   INSTANCE_PROFILE_EMBEDS: {{ .Values.pixelfed.instance.profile_embeds | quote }}
@@ -95,6 +95,17 @@ data:
   FILESYSTEM_CLOUD: {{ .Values.pixelfed.filesystem.cloud }}
   MEDIA_DELETE_LOCAL_AFTER_CLOUD: {{ .Values.pixelfed.media_delete_local_after_cloud | quote }}
 
+  # S3 configuration (non-secret values)
+  {{- if .Values.pixelfed.s3.bucket }}
+  AWS_BUCKET: {{ .Values.pixelfed.s3.bucket | quote }}
+  {{- end }}
+  {{- if .Values.pixelfed.s3.region }}
+  AWS_DEFAULT_REGION: {{ .Values.pixelfed.s3.region | quote }}
+  {{- end }}
+  {{- if .Values.pixelfed.s3.use_path_style_endpoint }}
+  AWS_USE_PATH_STYLE_ENDPOINT: {{ .Values.pixelfed.s3.use_path_style_endpoint | quote }}
+  {{- end }}
+
   # covid
   ENABLE_COVID_LABEL: {{ .Values.pixelfed.covid.enable_label | quote }}
   COVID_LABEL_URL: {{ .Values.pixelfed.covid.label_url | quote }}
@@ -140,7 +151,7 @@ data:
   {{- if .Values.valkey.enabled }}
   REDIS_HOST: {{ printf "%s-primary" (.Values.valkey.fullnameOverride) }}
   {{- else if and .Values.externalValkey.enabled (not .Values.externalValkey.existingSecret) (not .Values.externalValkey.existingSecretKeys.host) }}
-  REDIS_HOST: {{ .Values.externalValkey.port | quote }}
+  REDIS_HOST: {{ .Values.externalValkey.host | quote }}
   {{- end }}
 
   {{- if .Values.valkey.enabled }}

--- a/charts/pixelfed/templates/deployment.yaml
+++ b/charts/pixelfed/templates/deployment.yaml
@@ -244,6 +244,59 @@ spec:
                   {{- end }}
               {{- end }}
 
+            # S3 configuration
+            {{- if or .Values.pixelfed.s3.url .Values.pixelfed.s3.existingSecret }}
+            - name: AWS_URL
+              valueFrom:
+                secretKeyRef:
+                  {{- if and .Values.pixelfed.s3.existingSecret .Values.pixelfed.s3.existingSecretKeys.url }}
+                  name: {{ .Values.pixelfed.s3.existingSecret }}
+                  key: {{ .Values.pixelfed.s3.existingSecretKeys.url }}
+                  {{- else }}
+                  name: {{ include "pixelfed.fullname" . }}-s3
+                  key: url
+                  {{- end }}
+            {{- end }}
+
+            {{- if or .Values.pixelfed.s3.endpoint .Values.pixelfed.s3.existingSecret }}
+            - name: AWS_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  {{- if and .Values.pixelfed.s3.existingSecret .Values.pixelfed.s3.existingSecretKeys.endpoint }}
+                  name: {{ .Values.pixelfed.s3.existingSecret }}
+                  key: {{ .Values.pixelfed.s3.existingSecretKeys.endpoint }}
+                  {{- else }}
+                  name: {{ include "pixelfed.fullname" . }}-s3
+                  key: endpoint
+                  {{- end }}
+            {{- end }}
+
+            {{- if or .Values.pixelfed.s3.access_key_id .Values.pixelfed.s3.existingSecret }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  {{- if and .Values.pixelfed.s3.existingSecret .Values.pixelfed.s3.existingSecretKeys.access_key_id }}
+                  name: {{ .Values.pixelfed.s3.existingSecret }}
+                  key: {{ .Values.pixelfed.s3.existingSecretKeys.access_key_id }}
+                  {{- else }}
+                  name: {{ include "pixelfed.fullname" . }}-s3
+                  key: access_key_id
+                  {{- end }}
+            {{- end }}
+
+            {{- if or .Values.pixelfed.s3.secret_access_key .Values.pixelfed.s3.existingSecret }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  {{- if and .Values.pixelfed.s3.existingSecret .Values.pixelfed.s3.existingSecretKeys.secret_access_key }}
+                  name: {{ .Values.pixelfed.s3.existingSecret }}
+                  key: {{ .Values.pixelfed.s3.existingSecretKeys.secret_access_key }}
+                  {{- else }}
+                  name: {{ include "pixelfed.fullname" . }}-s3
+                  key: secret_access_key
+                  {{- end }}
+            {{- end }}
+
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/pixelfed/templates/secret_s3.yaml
+++ b/charts/pixelfed/templates/secret_s3.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.pixelfed.s3.url (not .Values.pixelfed.s3.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pixelfed.fullname" . }}-s3
+  labels:
+    {{- include "pixelfed.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.pixelfed.s3.url }}
+  url: {{ .Values.pixelfed.s3.url | b64enc }}
+  {{- end }}
+  {{- if .Values.pixelfed.s3.endpoint }}
+  endpoint: {{ .Values.pixelfed.s3.endpoint | b64enc }}
+  {{- end }}
+  {{- if .Values.pixelfed.s3.access_key_id }}
+  access_key_id: {{ .Values.pixelfed.s3.access_key_id | b64enc }}
+  {{- end }}
+  {{- if .Values.pixelfed.s3.secret_access_key }}
+  secret_access_key: {{ .Values.pixelfed.s3.secret_access_key | b64enc }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
### 1. Fix REDIS_HOST bug in configmap_env.yaml - was incorrectly using
   `.Values.externalValkey.port instead of .Values.externalValkey.host`

### 2. Add S3/AWS configuration support:
   - Add AWS_BUCKET, AWS_DEFAULT_REGION, AWS_USE_PATH_STYLE_ENDPOINT to configmap
   - Create secret_s3.yaml for S3 credentials (url, endpoint, access_key_id, secret_access_key)
   - Add S3 secret references in deployment.yaml for AWS_URL, AWS_ENDPOINT,
     AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY

### 3. Support for existingSecret with S3 credentials

Fixes the missing S3 environment variables that prevented Pixelfed from
connecting to S3-compatible storage backends like SeaweedFS, MinIO, etc."
### 4. Fixed contact mail 
- Changed `{{- with .Values.pixelfed.instance.contact_email }}` to `{{- if .Values.pixelfed.instance.contact_email }}`
---
*PR sponsored by [Obmondo.com](https://obmondo.com)*
---
**Note:** Since this is a company-paid contribution, we fork to the company account repo on GitHub. GitHub does not support "allow maintainer to edit in repo" for organization accounts.
 - Maintainers can either provide feedback for required changes before merging, OR
 - Pull our branch, make changes in their repo, and create a new PR including our commits.

